### PR TITLE
docs: roadmap + architecture + TDD plan (issues #1/#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full design.
 | [`llama-sampling`](crates/llama-sampling) | Sampling strategies (temperature, top-k/p) |
 | [`llama-kv`](crates/llama-kv) | KV cache management and paging |
 
+## Planning Docs
+
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — Epic + user stories + milestones (tracks [#1](https://github.com/stevedores-org/llama.rs/issues/1), [#2](https://github.com/stevedores-org/llama.rs/issues/2))
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — Modular architecture, crate boundaries, invariants
+- [`docs/TEST_STRATEGY.md`](docs/TEST_STRATEGY.md) — TDD plan: unit/property/golden/parity/perf testing
+
 ## Development
 
 ```bash

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,20 @@
 # Architecture
 
-> Copied from [Issue #1](https://github.com/stevedores-org/llama.rs/issues/1) — the canonical architecture and TDD plan.
+Status: Draft (updated 2026-02-15)
 
-## "Narrow Waist" + Replaceable Internals
+Directive: build a **modular, resilient, and accelerated inference runtime** in Rust, using [oxidizedMLX](https://github.com/stevedores-org/oxidizedMLX) for tensor/runtime + Metal, [oxidizedRAG](https://github.com/stevedores-org/oxidizedRAG) for retrieval/memory, and [oxidizedgraph](https://github.com/stevedores-org/oxidizedgraph) for agent orchestration.
+
+The goal is a **real app runtime** (streaming, sessions, KV cache, tools), not just a model runner.
+
+## Design Principles
+
+- **Narrow waist**: the `LlamaEngine` trait is the single stable interface that all consumers depend on.
+- Unsafe code is quarantined to a small surface and wrapped in typed, safe APIs.
+- API stability: keep public interfaces narrow, versioned, and testable.
+- Resilience by default: cancellation, timeouts, backpressure, bounded memory.
+- Performance is a feature: avoid unnecessary copies, allow zero/low-copy IO (mmap), and expose tuning knobs.
+
+## Crate Layout
 
 ```
 llama.rs/
@@ -13,65 +25,81 @@ llama.rs/
     llama-tokenizer/     # tokenizers + chat templates
     llama-sampling/      # samplers + penalties + stop conditions
     llama-kv/            # KV cache layouts + paging/eviction
+  docs/
+    ARCHITECTURE.md      # this file
+    MILESTONE_A.md       # first milestone checklist
+    ROADMAP.md           # epic + user story plan
+    TEST_STRATEGY.md     # TDD approach + CI expectations
 ```
 
-## The Narrow Waist: `llama-engine`
+Future crates (not yet scaffolded):
+- `llama-server` — OpenAI-compatible HTTP API ([LLAMA-009](https://github.com/stevedores-org/llama.rs/issues/12))
+- `llama-cli` — CLI runner for debug + bench
+- `llama-rag` — oxidizedRAG adapter ([LLAMA-011](https://github.com/stevedores-org/llama.rs/issues/14))
+- `llama-agents` — oxidizedgraph nodes ([LLAMA-012](https://github.com/stevedores-org/llama.rs/issues/15))
 
-Everything else plugs into this.
+## The Narrow Waist: `LlamaEngine` Trait
 
-**Core trait:**
-- `load_model(spec) -> ModelHandle`
-- `tokenize(text) -> Vec<i32>`
-- `detokenize(tokens) -> String`
-- `prefill(session, prompt_tokens) -> PrefillResult` — build KV cache
-- `decode(session) -> TokenStream` — streaming generation
-- `embed(texts) -> Vec<Vec<f32>>` — for oxidizedRAG
+Everything else plugs into this. Defined in `llama-engine` ([LLAMA-001](https://github.com/stevedores-org/llama.rs/issues/4)):
+
+```rust
+pub trait LlamaEngine: Send + Sync {
+    fn load_model(&self, spec: &ModelSpec) -> Result<ModelHandle>;
+    fn tokenize(&self, text: &str) -> Result<Vec<i32>>;
+    fn detokenize(&self, tokens: &[i32]) -> Result<String>;
+    fn prefill(&self, session: &mut Session, tokens: &[i32]) -> Result<PrefillResult>;
+    fn decode(&self, session: &mut Session) -> Result<TokenStream>;
+    fn embed(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>>;
+}
+```
 
 **Why this matters:**
 - oxidizedRAG and oxidizedgraph both depend on *engine behavior*, not implementation details.
 - You can swap CPU/Metal/FFI backends under `llama-runtime` without changing the app.
 
-## Runtime: `llama-runtime`
+## Key Crates
 
-- Backend selection (`cpu|metal|ffi`) + gating
+### `llama-engine` — Core types and trait
+- `LlamaEngine` trait (the narrow waist)
+- `ModelSpec`, `ModelHandle`, `Session`, `PrefillResult`, `TokenStream`
+- `LlamaError` typed error enum (not `String`)
+
+### `llama-tokenizer` — Deterministic tokenization ([LLAMA-002](https://github.com/stevedores-org/llama.rs/issues/5))
+- Load HF `tokenizer.json` and SentencePiece assets
+- Chat templates per model family
+- Streaming detokenize (handle partial UTF-8)
+
+### `llama-models` — Model architectures ([LLAMA-005](https://github.com/stevedores-org/llama.rs/issues/8))
+- RMSNorm, RoPE, MLP, Attention blocks
+- Weight loading from safetensors
+- Graph-friendly (oxidizedMLX lazy graph) but efficient for decode
+
+### `llama-runtime` — Backend selection ([LLAMA-007](https://github.com/stevedores-org/llama.rs/issues/10))
+- Backend selection (`cpu|metal`) via feature gates
 - Tensor allocator policy
 - Kernel availability matrix (what ops are supported on Metal)
 - Telemetry hooks (TTFT, tok/s, memory, KV cache size)
 
-## Model Definitions: `llama-models`
-
-Inference-first model blocks:
-- Embeddings
-- Attention block (with RoPE)
-- RMSNorm/LayerNorm
-- MLP
-- Output head
-
-Graph-friendly (oxidizedMLX lazy graph) but also efficient for decode.
-
-## KV Cache: `llama-kv`
-
-First-class KV cache that supports:
-- **Prefill** writes K/V for `[seq, heads, head_dim]`
-- **Decode** appends 1 token at a time
-- Memory-friendly layout (contiguous by head or by token)
-- Future: paging/eviction / sliding window
-
-## Tokenization: `llama-tokenizer`
-
-- Load tokenizer assets (json/sentencepiece/etc.)
-- Chat templates per model (system/user/assistant format)
-- Streaming detokenize (handle partial UTF-8)
-
-## Sampling: `llama-sampling`
-
+### `llama-sampling` — Sampling strategies ([LLAMA-003](https://github.com/stevedores-org/llama.rs/issues/6))
 - Greedy, temperature, top-k/top-p
 - Repetition penalty, stop sequences
-- Deterministic seeded RNG for tests
+- Deterministic seeded RNG for reproducible tests
 
-## TDD: True Tests
+### `llama-kv` — KV cache management ([LLAMA-004](https://github.com/stevedores-org/llama.rs/issues/7))
+- Prefill writes K/V for `[seq, heads, head_dim]`
+- Decode appends 1 token at a time
+- Memory-friendly layout for Metal/CPU shared memory
+- Future: paging/eviction / sliding window
 
-1. **Bit-Perfect Tokenization:** `detokenize(tokenize(x)) == x`
-2. **KV Equivalence:** `prefill + 1-step decode logits == full forward logits`
-3. **Cross-Backend Parity:** Metal result == CPU result (within float tolerance)
-4. **Cancellation Safety:** Dropping a Future/TokenStream terminates graph execution immediately
+## Acceleration Strategy
+
+The runtime exposes capability discovery rather than hard-coding platform rules:
+- Feature gates (`metal`, `cpu`) control backend compilation
+- Kernel availability matrix validates op support at startup
+- Backend parity gate ([LLAMA-008](https://github.com/stevedores-org/llama.rs/issues/11)): Metal can't be default unless parity tests pass
+
+## Session & Cancellation ([LLAMA-010](https://github.com/stevedores-org/llama.rs/issues/13))
+
+- Cancellation is cooperative and prompt; dropping a `TokenStream` terminates graph execution
+- Bounded memory: context size and KV cache behavior are explicit and configurable
+- Session ID maps to KV cache lifecycle (freed or archived on completion)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,89 @@
+# Roadmap (Epic + User Stories)
+
+Status: Open (updated 2026-02-15)
+
+This roadmap aligns with the architectural directive: build a **modular, resilient, and accelerated inference runtime** in Rust using oxidizedMLX, oxidizedRAG, and oxidizedgraph.
+
+Tracking:
+- **Primary planning tracker:** [Issue #2](https://github.com/stevedores-org/llama.rs/issues/2) (Epic and User Story plan)
+- **Supporting architecture context:** [Issue #1](https://github.com/stevedores-org/llama.rs/issues/1)
+
+---
+
+## Epic 1: Repository Foundation & Core Engine Abstraction
+
+Goal: establish the Rust workspace, define the core traits that mediate between model logic and hardware, and implement deterministic tokenization.
+
+| Story | Issue | Description |
+|-------|-------|-------------|
+| LLAMA-001 | [#4](https://github.com/stevedores-org/llama.rs/issues/4) | Modular workspace and narrow-waist `LlamaEngine` trait |
+| LLAMA-002 | [#5](https://github.com/stevedores-org/llama.rs/issues/5) | Robust tokenizer crate with streaming UTF-8 support |
+| LLAMA-003 | [#6](https://github.com/stevedores-org/llama.rs/issues/6) | Foundational sampling crate (greedy, top-k/p, temperature) |
+
+## Epic 2: Inference Logic & KV Cache Management
+
+Goal: implement graph-friendly model architectures and first-class memory management for token sequences.
+
+| Story | Issue | Description |
+|-------|-------|-------------|
+| LLAMA-004 | [#7](https://github.com/stevedores-org/llama.rs/issues/7) | First-class KV Cache (prefill, decode, paging) |
+| LLAMA-005 | [#8](https://github.com/stevedores-org/llama.rs/issues/8) | Llama 3 and Qwen model blocks in Rust |
+| LLAMA-006 | [#9](https://github.com/stevedores-org/llama.rs/issues/9) | Prefill vs. Decode verification suite (KV equivalence) |
+
+## Epic 3: Hardware Acceleration & Backend Parity
+
+Goal: integrate oxidizedMLX and enforce strict parity between CPU and Metal backends.
+
+| Story | Issue | Description |
+|-------|-------|-------------|
+| LLAMA-007 | [#10](https://github.com/stevedores-org/llama.rs/issues/10) | Runtime selector for oxidizedMLX backends |
+| LLAMA-008 | [#11](https://github.com/stevedores-org/llama.rs/issues/11) | Backend Parity Gate (Metal vs CPU golden tests) |
+
+## Epic 4: Application Surface & OpenAI-Compatible Server
+
+Goal: expose the engine via a high-performance HTTP server with streaming, sessions, and cancellation.
+
+| Story | Issue | Description |
+|-------|-------|-------------|
+| LLAMA-009 | [#12](https://github.com/stevedores-org/llama.rs/issues/12) | OpenAI-compatible HTTP server (`/v1/chat/completions`) |
+| LLAMA-010 | [#13](https://github.com/stevedores-org/llama.rs/issues/13) | Session and cancellation management |
+
+## Epic 5: Agentic Compute & Data Fabric Integration
+
+Goal: integrate with the broader "oxidized" ecosystem for RAG and multi-agent orchestration.
+
+| Story | Issue | Description |
+|-------|-------|-------------|
+| LLAMA-011 | [#14](https://github.com/stevedores-org/llama.rs/issues/14) | RAG adapter for oxidizedRAG |
+| LLAMA-012 | [#15](https://github.com/stevedores-org/llama.rs/issues/15) | Agent orchestration via oxidizedgraph |
+
+---
+
+## Milestones
+
+**Milestone A — "Hello Inference" (CPU only)**
+- Workspace scaffold + `LlamaEngine` trait *(done: [PR #16](https://github.com/stevedores-org/llama.rs/pull/16))*
+- Tokenizer loads + roundtrip tests
+- Tiny model forward (single block) on CPU
+- Greedy sampling
+- CLI: `llama-cli generate --prompt "hi"`
+
+**Milestone B — KV Cache Correctness (prefill + decode)**
+- KV cache struct + layout
+- Prefill writes cache; decode uses cache
+- Streaming `TokenStream`
+- KV equivalence test: `full_forward == prefill + decode`
+
+**Milestone C — Real Weight Loading (safetensors)**
+- oxidizedMLX `mlx-io` safetensors integration
+- Tensor name mapping + shape/dtype validation
+- Memory footprint sanity checks
+
+**Milestone D — Metal Enablement Behind Parity Gate**
+- Required op set for chosen model family
+- Parity suite (Metal vs CPU) for ops and attention block
+- Feature flag gating default backend
+
+**Milestone E — RAG + Agents (Product)**
+- oxidizedRAG adapter with citation prompt builder
+- oxidizedgraph agent nodes: Retrieve → Rerank → Prompt → Generate

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -1,0 +1,73 @@
+# Test Strategy (TDD)
+
+Status: Draft (updated 2026-02-15)
+
+Goal: enable fast feedback while building a modular inference runtime with oxidizedMLX backends.
+
+## Testing Pyramid
+
+### 1. Unit tests (fast, deterministic) — always on PR
+- Validate error mapping, config validation, cancellation/backpressure behavior
+- Tokenization roundtrip and edge cases
+- Sampling determinism (seeded RNG)
+- Use fake backends for runtime tests where possible
+
+### 2. Property tests (robustness) — on PR
+- Tokenization invariants: shapes, encoding/decoding edge cases
+- KV cache append-only invariant: cache length increases by 1 per decode
+- Graph arena: node count doesn't grow unbounded per token
+
+### 3. Golden tests (Python reference comparison) — PR small, nightly full
+- Tiny forward pass matches Python reference outputs within tolerance (`1e-5`)
+- Logits for a fixed prompt match reference
+- Tokenization outputs match HF tokenizer for a fixed set of prompts
+- End-to-end "1-turn chat": fixed prompt + weights → first N tokens match reference
+
+### 4. Backend parity tests (Metal vs CPU) — nightly on Apple Silicon
+- Op-level: Metal matmul/attention result == CPU result (within float tolerance)
+- Attention block "Golden Test" passes across all enabled backends
+- Stress: concurrent sessions on same device don't deadlock
+
+### 5. Performance tests (regression gates) — nightly/weekly
+- Criterion benchmarks for token throughput/latency
+- TTFT (time to first token) tracking
+- Memory footprint regression detection
+- Optional flamegraph capture (not required for CI)
+
+## True Tests (Critical Correctness Gates)
+
+These are enforced in CI as hard gates:
+
+1. **Bit-Perfect Tokenization:** `detokenize(tokenize(x)) == x` (allowing normalization)
+2. **KV Equivalence:** `full_forward(prompt) logits == prefill(prompt[:-1]) + decode(last_token) logits`
+3. **Cross-Backend Parity:** Metal result == CPU result (within float tolerance)
+4. **Cancellation Safety:** Dropping a `Future`/`TokenStream` terminates graph execution immediately
+
+## Fixtures
+
+- Prefer small safetensors fixtures (tiny model) for golden tests
+- For hermetic tests, use mock/stub backends (no model files required)
+- `tests/fixtures/` directory for tiny models, tokenizers, safetensors fixtures
+- `tools/py_ref/` for Python reference test generation scripts
+
+## TDD Workflow For New Capability
+
+For each feature slice:
+1. Write a failing unit test for the new API contract (validation, error types, or state transition).
+2. If a golden reference exists, add a golden test comparing against Python outputs.
+3. If backend-specific, add a parity test (Metal vs CPU).
+4. Add a micro-benchmark only after correctness is established.
+
+## What To Test First (Order)
+
+1. Tokenizer roundtrip: `detokenize(tokenize(x)) == x`
+2. Sampling determinism: fixed logits + seed → fixed sequence
+3. KV cache equivalence: prefill + 1-step decode == full forward
+4. Attention block golden: fixed Q/K/V → compare SDPA output vs numpy reference
+5. Cancellation: generation stops quickly and does not corrupt state
+
+## CI Expectations
+
+- **Per PR:** `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --workspace`
+- **Nightly:** golden tests (full suite), backend parity (Apple Silicon), performance benchmarks
+- **On demand:** soak tests, memory profiling


### PR DESCRIPTION
Adds planning docs and links them from README.\n\n- docs/ROADMAP.md: epic + user stories + milestones (tracks issues #1/#2)\n- docs/ARCHITECTURE.md: modular target architecture + crate boundaries\n- docs/TEST_STRATEGY.md: TDD approach + CI expectations\n\nFollow-ups:\n- convert repo to workspace once llama.cpp FFI begins\n- replace String errors with typed errors