### PR TITLE
feat: Tokenizer trait and reference implementation

### DIFF
--- a/crates/llama-tokenizer/Cargo.toml
+++ b/crates/llama-tokenizer/Cargo.toml
@@ -7,3 +7,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+thiserror.workspace = true


### PR DESCRIPTION
## Summary

Implements the core `Tokenizer` trait and `WhitespaceTokenizer` reference implementation for Milestone A.

- **Tokenizer trait**: Pluggable interface for encode/decode/decode_token
- **WhitespaceTokenizer**: Reference implementation for golden testing
- **DecodingState**: Streaming UTF-8 handling for token-by-token decoding
- **7 unit tests**: All passing (empty input, roundtrip, streaming, etc.)

## Part of
- Addresses #2 (LLAMA-002): Robust tokenizer crate with streaming support
- Milestone A: "Hello Inference" (CPU only)

## Test plan
- [x] Unit tests for whitespace tokenizer
- [x] Roundtrip encode/decode correctness
- [x] Empty input handling
- [x] Streaming decode state management

## Notes
- This is a reference implementation; real tokenizers (HF tokenizer.json, SentencePiece) will be added later
- Trait design allows swapping implementations without changing app code
- Ready for integration with llama-engine and session management