### PR TITLE
fix: address PR17 tokenizer review findings

### DIFF
--- a/crates/llama-tokenizer/Cargo.toml
+++ b/crates/llama-tokenizer/Cargo.toml
@@ -7,3 +7,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+thiserror.workspace = true


### PR DESCRIPTION
Addresses the request-changes review on #17 for the reference WhitespaceTokenizer.\n\nFixed:\n- encode/decode now use tokenizer state (no throwaway instances)\n- stable token IDs via shared vocabulary map\n- decode returns real mapped tokens and errors on unknown IDs\n- decode_token now decodes the provided token and updates streaming state\n- vocab_size now returns actual vocabulary size\n- roundtrip test now asserts decoded content equality\n- added tests for decode_token path, invalid token handling, and vocab size\n- switched TokenizerError to thiserror derive\n\nValidation:\n- cargo test -p llama-tokenizer\n- cargo clippy -p llama-tokenizer --all-targets -- -D warnings