### PR TITLE
docs: priorities (P1 RAG) + gh labels (cursor, llama.rs)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,15 @@
+# Repository labels
+
+Use these labels on issues and PRs for filtering and triage. Create them with `./scripts/create-labels.sh` (requires `gh` and auth).
+
+| Label       | Color   | Use for |
+|------------|---------|--------|
+| `cursor`   | `#0E8A16` | Work done or proposed from Cursor IDE / AI-assisted |
+| `llama.rs` | `#FEF2C0` | In scope for this repo (stevedores-org/llama.rs) |
+| `docs`     | `#0052CC` | Documentation, roadmap, architecture |
+| `roadmap`  | `#5319E7` | Roadmap / planning / priorities |
+| `priority` | `#B60205` | Priority / P1 items |
+| `rag`      | `#1D76DB` | RAG / semantic search / oxidizedRAG |
+| `good first issue` | `#7057FF` | Good for new contributors |
+
+When opening PRs from Cursor branches (e.g. `cursor/featA`), add labels: `cursor`, `llama.rs`, and any of `docs`, `roadmap`, `priority`, `rag` as applicable.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full design.
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) — Epic + user stories + milestones (tracks [#1](https://github.com/stevedores-org/llama.rs/issues/1), [#2](https://github.com/stevedores-org/llama.rs/issues/2))
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — Modular architecture, crate boundaries, invariants
 - [`docs/TEST_STRATEGY.md`](docs/TEST_STRATEGY.md) — TDD plan: unit/property/golden/parity/perf testing
+- [`.github/LABELS.md`](.github/LABELS.md) — Recommended gh labels (`cursor`, `llama.rs`, `docs`, `roadmap`, `priority`, `rag`); create with `./scripts/create-labels.sh`
 
 ## Development
 

--- a/scripts/create-labels.sh
+++ b/scripts/create-labels.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Create recommended gh labels for stevedores-org/llama.rs.
+# Run from repo root with: ./scripts/create-labels.sh
+# Requires: gh auth login (or GH_TOKEN)
+
+set -e
+REPO="${REPO:-stevedores-org/llama.rs}"
+
+create() {
+  local name="$1" color="$2" desc="$3"
+  if gh label view "$name" --repo "$REPO" &>/dev/null; then
+    echo "Label '$name' exists, skipping."
+  else
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$desc"
+    echo "Created label: $name"
+  fi
+}
+
+create "cursor"       "0E8A16" "Work from Cursor IDE / AI-assisted"
+create "llama.rs"      "FEF2C0" "In scope for stevedores-org/llama.rs"
+create "docs"          "0052CC" "Documentation, roadmap, architecture"
+create "roadmap"       "5319E7" "Roadmap / planning / priorities"
+create "priority"      "B60205" "Priority / P1 items"
+create "rag"           "1D76DB" "RAG / semantic search / oxidizedRAG"
+create "good first issue" "7057FF" "Good for new contributors"
+
+echo "Done. Use: gh pr create --base main --head cursor/featA --label cursor --label llama.rs --label docs"
+echo "Or: gh issue list --label cursor --label llama.rs"


### PR DESCRIPTION
## Summary
- **Priorities** section in ROADMAP: P1 = semantic search / RAG (see Epic 5 / LLAMA-011).
- **Labels**: `.github/LABELS.md` and `scripts/create-labels.sh` for `cursor`, `llama.rs`, `docs`, `roadmap`, `priority`, `rag`.
- README link to label docs and create script.

Labels: cursor, llama.rs, docs, roadmap

Made with [Cursor](https://cursor.com)