### PR TITLE
fix: rustfmt long assert_eq line in tokenizer tests

### DIFF
--- a/crates/llama-tokenizer/src/lib.rs
+++ b/crates/llama-tokenizer/src/lib.rs
@@ -225,7 +225,10 @@ mod tests {
     fn decode_invalid_token_errors() {
         let tok = WhitespaceTokenizer::new();
         tok.encode("hello").unwrap();
-        assert_eq!(tok.decode(&[999]).unwrap_err(), TokenizerError::InvalidToken(999));
+        assert_eq!(
+            tok.decode(&[999]).unwrap_err(),
+            TokenizerError::InvalidToken(999)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Wrap long `assert_eq!` line at `crates/llama-tokenizer/src/lib.rs:228` to pass `cargo fmt --check`
- This is the failing check on PR #33 (develop→main merge)

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p llama-tokenizer` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)