### PR TITLE
feat: LLAMA-004 paging/eviction interface for KV cache

### DIFF
--- a/crates/llama-kv/src/lib.rs
+++ b/crates/llama-kv/src/lib.rs
@@ -676,10 +676,7 @@ mod tests {
             .unwrap();
         // t2: h0=[9,10], h1=[11,12]
         cache
-            .append_token(
-                &[9.0, 10.0, 11.0, 12.0],
-                &[90.0, 100.0, 110.0, 120.0],
-            )
+            .append_token(&[9.0, 10.0, 11.0, 12.0], &[90.0, 100.0, 110.0, 120.0])
             .unwrap();
 
         cache.evict_prefix(1).unwrap();
@@ -704,10 +701,7 @@ mod tests {
             .append_token(&[5.0, 6.0, 7.0, 8.0], &[50.0, 60.0, 70.0, 80.0])
             .unwrap();
         cache
-            .append_token(
-                &[9.0, 10.0, 11.0, 12.0],
-                &[90.0, 100.0, 110.0, 120.0],
-            )
+            .append_token(&[9.0, 10.0, 11.0, 12.0], &[90.0, 100.0, 110.0, 120.0])
             .unwrap();
 
         cache.evict_prefix(1).unwrap();

--- a/crates/llama-runtime/tests/kv_equivalence.rs
+++ b/crates/llama-runtime/tests/kv_equivalence.rs
@@ -248,7 +248,9 @@ mod tests {
                 *prompt.get(7).unwrap_or(&0),
             ];
 
-            let report = verifier.verify_kv_equivalence(&prompt_array[..len]).unwrap();
+            let report = verifier
+                .verify_kv_equivalence(&prompt_array[..len])
+                .unwrap();
             assert!(
                 report.max_abs_diff <= 1e-5,
                 "Length {}: KV equivalence should hold within 1e-5, got {}",


### PR DESCRIPTION
Implements the remaining LLAMA-004 gap with a concrete paging/eviction API (single atomic PR on develop).

Included:
- New KvPager trait with apply_sliding_window(window)
- LayerKVCache::evict_prefix(count) with compaction semantics
- KvPager implementations for both LayerKVCache and SessionKVCache
- New KVError::EvictionOutOfRange for invalid eviction requests

Tests added:
- evict_prefix_compacts_oldest_tokens
- sliding_window_evicts_expected_count
- session_sliding_window_applies_to_all_layers
- evict_prefix_out_of_range_errors

Validation:
- cargo test -p llama-kv
- cargo clippy -p llama-kv --all-targets -- -D warnings

Refs #7
Refs #42
