### PR TITLE
fix: address Copilot review comments on PR #59

### DIFF
--- a/crates/llama-kv/src/lib.rs
+++ b/crates/llama-kv/src/lib.rs
@@ -343,8 +343,10 @@ impl SessionKVCache {
     }
 
     /// Get current sequence length (same for all layers by invariant).
+    ///
+    /// Returns 0 if no layers exist (though the constructor prevents this).
     pub fn seq_len(&self) -> usize {
-        self.layers[0].seq_len
+        self.layers.first().map(|l| l.seq_len).unwrap_or(0)
     }
 
     /// Append K/V for one token to all layers atomically.

--- a/crates/llama-runtime/src/lib.rs
+++ b/crates/llama-runtime/src/lib.rs
@@ -30,6 +30,11 @@ use std::thread;
 ///
 /// Uses a simple whitespace tokenizer and greedy sampler to demonstrate
 /// the "narrow waist" API without requiring a real model or MLX backend.
+///
+/// **Note:** The mock `decode()` returns tokens from a shared sampler,
+/// ignoring the `Session` parameter. All sessions produce the same
+/// token sequence. This is intentional for testing the API contract;
+/// real engines track per-session KV cache state.
 pub struct MockEngine {
     tokenizer: WhitespaceTokenizer,
     sampler: Mutex<Sampler>,

--- a/crates/llama-sampling/src/lib.rs
+++ b/crates/llama-sampling/src/lib.rs
@@ -124,6 +124,10 @@ impl Sampler {
 }
 
 /// Greedy decoding (argmax).
+///
+/// Callers must ensure logits contain only finite values.
+/// NaN values will not compare greater than any value, so NaN-containing
+/// slices may return an arbitrary index.
 pub fn greedy_sample(logits: &[f32]) -> Result<i32, SamplingError> {
     if logits.is_empty() {
         return Err(SamplingError::EmptyLogits);

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,37 +4,42 @@ This directory contains the Phase 1 test suite that enforces the "True Tests" an
 
 ## Architecture
 
-The test suite is organized by concern:
+Tests live under individual crates as integration and unit tests. The groupings below are logical categories mapping to the actual test locations.
 
-### 1. Tokenizer Tests (`tokenizer/`)
+### 1. Tokenizer Tests
+**Location:** `crates/llama-tokenizer/tests/roundtrip.rs` + unit tests in `crates/llama-tokenizer/src/lib.rs`
 - **roundtrip**: `detokenize(tokenize(x)) == x` (True Test #1)
 - **streaming**: UTF-8 boundary handling for multi-byte characters
 - **property tests**: Random unicode strings and edge cases
 - **asset loading**: Validates tokenizer.json loading
 
-### 2. Sampler Tests (`sampler/`)
+### 2. Sampler Tests
+**Location:** unit tests in `crates/llama-sampling/src/lib.rs`
 - **determinism**: Seeded RNG produces identical results
 - **correctness**: Greedy, Top-K, Top-P, Temperature implementations
 - **edge cases**: top_k=1, top_p=0.0, temperature=0
 - **distributions**: Entropy scaling with temperature
 
-### 3. KV Cache & Inference Tests (`inference/`)
+### 3. KV Cache & Inference Tests
+**Location:** `crates/llama-runtime/tests/kv_equivalence.rs` + unit tests in `crates/llama-kv/src/lib.rs`
 - **kv_equivalence**: Full forward vs prefill+decode (True Test #2)
 - **rope_offset**: Position encoding correctness in decode phase
 - **shape_invariants**: Pre-alloc dimensions and write pointer correctness
 
-### 4. Model Block Golden Tests (`blocks/`)
+### 4. Model Block Golden Tests
+**Location:** unit tests in `crates/llama-models/src/lib.rs`
 - **rmsnorm**: Golden vector comparison against reference
 - **rope**: Small QK vectors with known sin/cos tables
 - **mlp**: Two-layer MLP with known weights
 - **attention**: Tiny attention case with reference implementation
 
-### 5. Backend Parity Tests (`backend_parity/`)
+### 5. Backend Parity Tests
+**Location:** `crates/llama-runtime/src/backend.rs` + `crates/llama-runtime/src/lib.rs`
 - **cpu_vs_metal**: Output comparison within tolerance
 - **kernel_matrix**: Runtime validation of required ops
 - **concurrent_sessions**: Stress test for deadlock freedom
 
-### 6. Cancellation Safety Tests (`cancellation/`)
+### 6. Cancellation Safety Tests (planned)
 - **cancel_flag**: AtomicBool stops generation promptly
 - **drop_stream**: Dropping receiver terminates inference thread
 - **kv_cleanup**: Memory released after cancellation
@@ -57,10 +62,9 @@ The test suite is organized by concern:
 # Run all tests
 cargo test --workspace
 
-# Run specific suite
-cargo test --test tokenizer_
-cargo test --test inference_
-cargo test --test backend_parity_ --features metal
+# Run specific test files
+cargo test --test roundtrip -p llama-tokenizer
+cargo test --test kv_equivalence -p llama-runtime
 
 # Run with logging
 RUST_LOG=debug cargo test --workspace -- --nocapture
@@ -78,10 +82,10 @@ cargo test concurrent_sessions -- --test-threads=1 --ignored
 
 A PR cannot merge if these fail:
 
-1. ✅ `tokenizer_roundtrip_*` - Bit-perfect tokenization
-2. ✅ `inference_kv_equivalence` - KV cache equivalence
-3. ✅ `backend_parity_*` (macOS) - CPU vs Metal output match
-4. ✅ `cancellation_*` - Cancellation safety
+1. Tokenizer roundtrip — Bit-perfect tokenization
+2. KV equivalence — KV cache equivalence
+3. Backend parity (macOS) — CPU vs Metal output match
+4. Cancellation safety (planned)
 
 ## References
 


### PR DESCRIPTION
## Summary
- Addresses 9 Copilot review comments from PR #59 (develop → main merge)
- 4 fixes applied, 5 assessed and intentionally left unchanged

## Changes

**Applied:**
- `SessionKVCache::seq_len`: defensive `.first().unwrap_or(0)` instead of direct `[0]` index
- `MockEngine`: doc comment noting decode() ignores Session (all sessions same sequence)
- `greedy_sample`: doc noting callers must ensure finite logits (NaN behavior)
- `tests/README.md`: fix test commands to match actual file names, clarify logical vs physical test organization

**Assessed — no change needed:**
- Repetition penalty at zero: mathematically correct as-is
- `normalize_probs` silent return: degenerate edge case, existing behavior fine
- `evict_prefix` efficiency: premature optimization, current impl correct
- MockEngine cast: i32→i32 is a no-op
- MockEngine bounds check: sampler already constrains output range

## Test plan
- [x] `cargo test --workspace` — 133 tests pass
- [x] No compilation warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)