### PR TITLE
Fix deterministic_jitter bias and enforce ToyModel dim

### DIFF
--- a/crates/llama-runtime/src/lib.rs
+++ b/crates/llama-runtime/src/lib.rs
@@ -468,7 +468,7 @@ fn deterministic_jitter(seed: u64, position: usize) -> f32 {
     let x = seed
         .wrapping_mul(0x9E37_79B9_7F4A_7C15)
         .wrapping_add(pos_mix);
-    let top = (x >> 40) as u32;
+    let top = (x >> 32) as u32;
     (top as f32 / u32::MAX as f32) - 0.5
 }
 
@@ -502,6 +502,7 @@ fn attention_single_head_cpu(
     seq_len: usize,
     dim: usize,
 ) -> [f32; 2] {
+    assert_eq!(dim, 2, "ToyModel supports only dim=2");
     let scale = 1.0 / (dim as f32).sqrt();
 
     let mut scores = vec![0.0f32; seq_len];


### PR DESCRIPTION
This PR fixes a bug in `deterministic_jitter` where the random value was generated using only the top 24 bits of a 64-bit value but divided by `u32::MAX`, resulting in a range of approximately `[0, 1/256)`. This caused the jitter to be consistently close to `-0.5` instead of the intended `[-0.5, 0.5)` range. The fix uses the top 32 bits to cover the full range.

Additionally, this PR adds an assertion in `attention_single_head_cpu` to explicitly enforce that `dim` is 2, as the implementation hardcodes a 2D dot product and returns a fixed-size array. This prevents potential silent errors if the function were used with other dimensions.


---
*PR created automatically by Jules for task [15592834467030992252](https://jules.google.com/task/15592834467030992252) started by @stevei101*