### PR TITLE
Fix mixed-NaN softmax bug and add edge-case tests

### DIFF
--- a/crates/llama-tokenizer/src/lib.rs
+++ b/crates/llama-tokenizer/src/lib.rs
@@ -755,8 +755,7 @@ mod tests {
           }
         }"#;
         let tok = LoadedTokenizer::from_tokenizer_json_str(json).unwrap();
-        // 'A' is 0x41. It should match "<0x41>" if we handle byte pieces.
-        // Currently it fails because "A" != "<0x41>".
+        // 'A' is 0x41. With byte-fallback, it encodes via the "<0x41>" byte piece.
         let encoded = tok.encode("A").unwrap();
         assert_eq!(encoded, vec![1]);
     }


### PR DESCRIPTION
## Summary
- **Fix NaN propagation bug**: `f32::max(NaN, x)` returns `x` in Rust (IEEE 754 `maxNum`), so mixed NaN+finite inputs bypassed the NaN guard and produced NaN output probabilities. Moved NaN detection to an explicit `any(|v| v.is_nan())` check *before* the fold, in all three softmax sites (`llama-sampling`, `llama-models`, `llama-runtime`).
- **Add missing test coverage**: 5 new tests per crate (15 total) covering all-NaN, mixed NaN+finite, all-NEG_INFINITY, all +INFINITY, and mixed +INFINITY+finite inputs.
- **Fix stale comment** in `llama-tokenizer` byte-fallback test.

Addresses review findings from #70.

## Test plan
- [x] `cargo test -p llama-sampling -p llama-models -p llama-runtime -p llama-tokenizer` — 117 tests pass
- [x] `cargo clippy` — no warnings
- [x] New tests verify mixed NaN+finite returns uniform distribution (previously produced NaN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)