### PR TITLE
Fix KV layout, tokenizer fidelity, and generalize ToyModel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ members = [
     "crates/llama-rag",
     "crates/llama-cli",
     "crates/llama-server",
-    "crates/llama-rag",
 ]
 
 [workspace.package]

--- a/crates/llama-cli/src/lib.rs
+++ b/crates/llama-cli/src/lib.rs
@@ -183,11 +183,23 @@ impl TinyModel {
         kv_cache.append_token(&k, &v)?;
 
         let seq_len = kv_cache.seq_len;
-        let keys = &kv_cache.k[..seq_len * d];
-        let values = &kv_cache.v[..seq_len * d];
 
         // 6. Attention: Q against all cached K, V
-        let attn_out = attention_decode(&q, keys, values, seq_len, c.n_heads, c.head_dim)?;
+        let layout = match kv_cache.layout {
+            llama_kv::KVLayout::BySequence => llama_models::KVLayout::BySequence,
+            llama_kv::KVLayout::ByHead => llama_models::KVLayout::ByHead,
+            llama_kv::KVLayout::Transposed => llama_models::KVLayout::Transposed,
+        };
+        let attn_out = attention_decode(
+            &q,
+            &kv_cache.k,
+            &kv_cache.v,
+            seq_len,
+            kv_cache.max_seq_len,
+            c.n_heads,
+            c.head_dim,
+            layout,
+        )?;
 
         // 7. Output projection + residual
         let attn_proj = Self::matvec(&attn_out, &self.w_o, d, d);
@@ -241,10 +253,22 @@ impl TinyModel {
             // output. Multi-layer models would need full computation per token.
             if pos == token_ids.len() - 1 {
                 let seq_len = kv_cache.seq_len;
-                let keys = &kv_cache.k[..seq_len * d];
-                let values = &kv_cache.v[..seq_len * d];
+                let layout = match kv_cache.layout {
+                    llama_kv::KVLayout::BySequence => llama_models::KVLayout::BySequence,
+                    llama_kv::KVLayout::ByHead => llama_models::KVLayout::ByHead,
+                    llama_kv::KVLayout::Transposed => llama_models::KVLayout::Transposed,
+                };
 
-                let attn_out = attention_decode(&q, keys, values, seq_len, c.n_heads, c.head_dim)?;
+                let attn_out = attention_decode(
+                    &q,
+                    &kv_cache.k,
+                    &kv_cache.v,
+                    seq_len,
+                    kv_cache.max_seq_len,
+                    c.n_heads,
+                    c.head_dim,
+                    layout,
+                )?;
                 let attn_proj = Self::matvec(&attn_out, &self.w_o, d, d);
                 let x_after_attn: Vec<f32> =
                     x.iter().zip(attn_proj.iter()).map(|(a, b)| a + b).collect();

--- a/crates/llama-cli/tests/layout_bug.rs
+++ b/crates/llama-cli/tests/layout_bug.rs
@@ -1,0 +1,32 @@
+use llama_cli::{TinyModel, TinyModelConfig};
+use llama_kv::{KVLayout, LayerKVCache};
+
+#[test]
+fn test_kv_layout_mismatch_bug() {
+    let config = TinyModelConfig::default();
+    let model = TinyModel::new(config.clone());
+
+    // Reference with BySequence
+    let mut cache_seq = LayerKVCache::new(
+        config.max_seq_len,
+        config.n_heads,
+        config.head_dim,
+        KVLayout::BySequence,
+    );
+    let logits_seq = model.forward_prefill(&[1, 2, 3], &mut cache_seq).unwrap();
+
+    // With ByHead - this SHOULD produce the same logits if it were correct,
+    // but attention_decode will read wrong values.
+    let mut cache_head = LayerKVCache::new(
+        config.max_seq_len,
+        config.n_heads,
+        config.head_dim,
+        KVLayout::ByHead,
+    );
+    let logits_head = model.forward_prefill(&[1, 2, 3], &mut cache_head).unwrap();
+
+    assert_eq!(
+        logits_seq, logits_head,
+        "Logits should be identical regardless of KV layout"
+    );
+}

--- a/crates/llama-models/src/lib.rs
+++ b/crates/llama-models/src/lib.rs
@@ -86,6 +86,19 @@ impl ModelWeights {
     }
 }
 
+/// Layout policy for KV cache memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KVLayout {
+    /// Contiguous by sequence position: `[seq_len][heads][head_dim]`
+    BySequence,
+
+    /// Contiguous by head: `[heads][seq_len][head_dim]`
+    ByHead,
+
+    /// Transposed for attention: `[heads][head_dim][seq_len]`
+    Transposed,
+}
+
 /// Root mean square normalization.
 pub fn rms_norm(input: &[f32], weight: &[f32], eps: f32) -> Result<Vec<f32>, ModelError> {
     if input.len() != weight.len() {
@@ -156,18 +169,22 @@ pub fn apply_rope(
 
 /// Single-step decode attention:
 /// - `query`: `[n_heads * head_dim]`
-/// - `keys`/`values`: `[seq_len * n_heads * head_dim]`
+/// - `keys`/`values`: backing storage for KV cache
 /// - output: `[n_heads * head_dim]`
+#[allow(clippy::too_many_arguments)]
 pub fn attention_decode(
     query: &[f32],
     keys: &[f32],
     values: &[f32],
     seq_len: usize,
+    max_seq_len: usize,
     n_heads: usize,
     head_dim: usize,
+    layout: KVLayout,
 ) -> Result<Vec<f32>, ModelError> {
     let q_expected = n_heads * head_dim;
-    let kv_expected = seq_len * n_heads * head_dim;
+    let kv_capacity = max_seq_len * n_heads * head_dim;
+
     if query.len() != q_expected {
         return Err(ModelError::Shape(format!(
             "query shape mismatch: expected {}, got {}",
@@ -175,10 +192,10 @@ pub fn attention_decode(
             query.len()
         )));
     }
-    if keys.len() != kv_expected || values.len() != kv_expected {
+    if keys.len() < kv_capacity || values.len() < kv_capacity {
         return Err(ModelError::Shape(format!(
-            "kv shape mismatch: expected {}, got k={}, v={}",
-            kv_expected,
+            "kv storage too small: expected capacity {}, got k={}, v={}",
+            kv_capacity,
             keys.len(),
             values.len()
         )));
@@ -187,24 +204,33 @@ pub fn attention_decode(
     let mut out = vec![0.0; q_expected];
     let scale = 1.0 / (head_dim as f32).sqrt();
 
+    let get_index = |seq: usize, head: usize, dim: usize| -> usize {
+        match layout {
+            KVLayout::BySequence => (seq * n_heads + head) * head_dim + dim,
+            KVLayout::ByHead => (head * max_seq_len + seq) * head_dim + dim,
+            KVLayout::Transposed => (head * head_dim + dim) * max_seq_len + seq,
+        }
+    };
+
     for h in 0..n_heads {
         let qh = &query[h * head_dim..(h + 1) * head_dim];
 
         let mut scores = vec![0.0f32; seq_len];
         for (t, score) in scores.iter_mut().enumerate() {
-            let kh_off = (t * n_heads + h) * head_dim;
-            let kh = &keys[kh_off..kh_off + head_dim];
-            let dot = qh.iter().zip(kh.iter()).map(|(&a, &b)| a * b).sum::<f32>();
+            let mut dot = 0.0f32;
+            for (i, &q_val) in qh.iter().enumerate().take(head_dim) {
+                let kh_idx = get_index(t, h, i);
+                dot += q_val * keys[kh_idx];
+            }
             *score = dot * scale;
         }
 
         let probs = softmax(&scores);
         for (t, &p) in probs.iter().enumerate() {
-            let vh_off = (t * n_heads + h) * head_dim;
-            let vh = &values[vh_off..vh_off + head_dim];
             let out_h = &mut out[h * head_dim..(h + 1) * head_dim];
-            for i in 0..head_dim {
-                out_h[i] += p * vh[i];
+            for (i, out_val) in out_h.iter_mut().enumerate().take(head_dim) {
+                let vh_idx = get_index(t, h, i);
+                *out_val += p * values[vh_idx];
             }
         }
     }
@@ -385,9 +411,44 @@ mod tests {
         let query = [1.0, 0.0];
         let keys = [1.0, 0.0, 0.0, 1.0]; // seq=2, heads=1, dim=2
         let values = [10.0, 0.0, 0.0, 20.0];
-        let out = attention_decode(&query, &keys, &values, 2, 1, 2).unwrap();
+        let out =
+            attention_decode(&query, &keys, &values, 2, 2, 1, 2, KVLayout::BySequence).unwrap();
         let expected = [6.697615, 6.60477];
         assert_close(&out, &expected, 1e-5);
+    }
+
+    #[test]
+    fn attention_supports_by_head_layout() {
+        let query = [1.0, 0.0, 0.0, 1.0]; // 2 heads, dim=2
+        let n_heads = 2;
+        let head_dim = 2;
+        let seq_len = 1;
+        let max_seq_len = 2;
+
+        // ByHead: [heads][max_seq_len][head_dim]
+        // h0: [[1,0], [0,0]], h1: [[0,1], [0,0]]
+        let mut keys = vec![0.0; n_heads * max_seq_len * head_dim];
+        keys[0] = 1.0;
+        keys[1] = 0.0; // h0, s0, d0, d1
+        keys[4] = 0.0;
+        keys[5] = 1.0; // h1, s0, d0, d1
+
+        let values = keys.clone();
+
+        let out = attention_decode(
+            &query,
+            &keys,
+            &values,
+            seq_len,
+            max_seq_len,
+            n_heads,
+            head_dim,
+            KVLayout::ByHead,
+        )
+        .unwrap();
+
+        // Each head should match its key/value
+        assert_close(&out, &query, 1e-5);
     }
 
     #[test]
@@ -465,7 +526,8 @@ mod tests {
         let query = [1.0, 0.0];
         let keys = [1.0, 0.0]; // seq=1, heads=1, dim=2
         let values = [3.0, 7.0];
-        let out = attention_decode(&query, &keys, &values, 1, 1, 2).unwrap();
+        let out =
+            attention_decode(&query, &keys, &values, 1, 1, 1, 2, KVLayout::BySequence).unwrap();
         assert_close(&out, &values, 1e-5);
     }
 

--- a/crates/llama-runtime/src/lib.rs
+++ b/crates/llama-runtime/src/lib.rs
@@ -351,27 +351,25 @@ impl BackendParityGate {
 
 #[derive(Debug)]
 struct ToyModel {
-    embeddings: [[f32; 2]; 8],
-    out_proj: [[f32; 8]; 2],
+    embeddings: Vec<f32>, // [vocab_size * dim]
+    out_proj: Vec<f32>,   // [dim * vocab_size]
+    dim: usize,
+    vocab_size: usize,
 }
 
 impl Default for ToyModel {
     fn default() -> Self {
+        let embeddings = vec![
+            0.4, -0.2, 0.1, 0.9, 0.8, 0.2, -0.5, 0.7, 0.3, -0.9, -0.2, -0.3, 0.6, 0.4, -0.7, 0.5,
+        ];
+        let out_proj = vec![
+            0.3, -0.1, 0.2, 0.5, -0.4, 0.1, 0.2, -0.3, -0.2, 0.6, -0.3, 0.1, 0.4, -0.5, 0.2, 0.3,
+        ];
         Self {
-            embeddings: [
-                [0.4, -0.2],
-                [0.1, 0.9],
-                [0.8, 0.2],
-                [-0.5, 0.7],
-                [0.3, -0.9],
-                [-0.2, -0.3],
-                [0.6, 0.4],
-                [-0.7, 0.5],
-            ],
-            out_proj: [
-                [0.3, -0.1, 0.2, 0.5, -0.4, 0.1, 0.2, -0.3],
-                [-0.2, 0.6, -0.3, 0.1, 0.4, -0.5, 0.2, 0.3],
-            ],
+            embeddings,
+            out_proj,
+            dim: 2,
+            vocab_size: 8,
         }
     }
 }
@@ -388,8 +386,9 @@ impl ToyModel {
         backend: RuntimeBackend,
     ) -> std::result::Result<Vec<f32>, RuntimeError> {
         let seq_len = prompt.len();
-        let mut keys = Vec::with_capacity(seq_len * 2);
-        let mut values = Vec::with_capacity(seq_len * 2);
+        let d = self.dim;
+        let mut keys = Vec::with_capacity(seq_len * d);
+        let mut values = Vec::with_capacity(seq_len * d);
 
         for (pos, &tok) in prompt.iter().enumerate() {
             let mut kv = self.token_vec(tok)?;
@@ -403,8 +402,8 @@ impl ToyModel {
         apply_seed_jitter(&mut q, seed, seq_len - 1);
         apply_position_rotation(&mut q, seq_len - 1);
 
-        let ctx = attention_single_head(&q, &keys, &values, seq_len, 2, backend);
-        Ok(project_logits(&ctx, &self.out_proj))
+        let ctx = attention_single_head(&q, &keys, &values, seq_len, d, backend);
+        Ok(project_logits(&ctx, &self.out_proj, self.vocab_size))
     }
 
     fn prefill_then_decode(
@@ -413,10 +412,11 @@ impl ToyModel {
         inject_off_by_one: bool,
     ) -> std::result::Result<Vec<f32>, RuntimeError> {
         let prefill_len = prompt.len() - 1;
-        let mut cache = LayerKVCache::new(prompt.len(), 1, 2, KVLayout::BySequence);
+        let d = self.dim;
+        let mut cache = LayerKVCache::new(prompt.len(), 1, d, KVLayout::BySequence);
 
-        let mut k_prefill = Vec::with_capacity(prefill_len * 2);
-        let mut v_prefill = Vec::with_capacity(prefill_len * 2);
+        let mut k_prefill = Vec::with_capacity(prefill_len * d);
+        let mut v_prefill = Vec::with_capacity(prefill_len * d);
         for (pos, &tok) in prompt[..prefill_len].iter().enumerate() {
             let mut kv = self.token_vec(tok)?;
             apply_position_rotation(&mut kv, pos);
@@ -439,28 +439,34 @@ impl ToyModel {
         cache.append_token(&kv_last, &kv_last)?;
 
         let seq_len = cache.seq_len;
-        let keys = cache.k[..seq_len * 2].to_vec();
-        let values = cache.v[..seq_len * 2].to_vec();
-        let ctx = attention_single_head(&q, &keys, &values, seq_len, 2, RuntimeBackend::Cpu);
-        Ok(project_logits(&ctx, &self.out_proj))
+        let keys = cache.k[..seq_len * d].to_vec();
+        let values = cache.v[..seq_len * d].to_vec();
+        let ctx = attention_single_head(&q, &keys, &values, seq_len, d, RuntimeBackend::Cpu);
+        Ok(project_logits(&ctx, &self.out_proj, self.vocab_size))
     }
 
-    fn token_vec(&self, token: i32) -> std::result::Result<[f32; 2], RuntimeError> {
+    fn token_vec(&self, token: i32) -> std::result::Result<Vec<f32>, RuntimeError> {
         let idx = usize::try_from(token).map_err(|_| RuntimeError::InvalidToken(token))?;
-        self.embeddings
-            .get(idx)
-            .copied()
-            .ok_or(RuntimeError::InvalidToken(token))
+        if idx >= self.vocab_size {
+            return Err(RuntimeError::InvalidToken(token));
+        }
+        let offset = idx * self.dim;
+        Ok(self.embeddings[offset..offset + self.dim].to_vec())
     }
 }
 
-fn apply_seed_jitter(v: &mut [f32; 2], seed: u64, position: usize) {
+fn apply_seed_jitter(v: &mut [f32], seed: u64, position: usize) {
     if seed == 0 {
         return;
     }
     let jitter = deterministic_jitter(seed, position) * 0.01;
-    v[0] += jitter;
-    v[1] -= jitter;
+    for (i, val) in v.iter_mut().enumerate() {
+        if i % 2 == 0 {
+            *val += jitter;
+        } else {
+            *val -= jitter;
+        }
+    }
 }
 
 fn deterministic_jitter(seed: u64, position: usize) -> f32 {
@@ -472,23 +478,27 @@ fn deterministic_jitter(seed: u64, position: usize) -> f32 {
     (top as f32 / u32::MAX as f32) - 0.5
 }
 
-fn apply_position_rotation(v: &mut [f32; 2], position: usize) {
+fn apply_position_rotation(v: &mut [f32], position: usize) {
     let theta = position as f32 * 0.15;
     let (sin_t, cos_t) = theta.sin_cos();
-    let x0 = v[0];
-    let x1 = v[1];
-    v[0] = x0 * cos_t - x1 * sin_t;
-    v[1] = x0 * sin_t + x1 * cos_t;
+    for i in (0..v.len()).step_by(2) {
+        if i + 1 < v.len() {
+            let x0 = v[i];
+            let x1 = v[i + 1];
+            v[i] = x0 * cos_t - x1 * sin_t;
+            v[i + 1] = x0 * sin_t + x1 * cos_t;
+        }
+    }
 }
 
 fn attention_single_head(
-    q: &[f32; 2],
+    q: &[f32],
     keys: &[f32],
     values: &[f32],
     seq_len: usize,
     dim: usize,
     backend: RuntimeBackend,
-) -> [f32; 2] {
+) -> Vec<f32> {
     match backend {
         RuntimeBackend::Cpu => attention_single_head_cpu(q, keys, values, seq_len, dim),
         RuntimeBackend::Metal => attention_single_head_metal(q, keys, values, seq_len, dim),
@@ -496,27 +506,31 @@ fn attention_single_head(
 }
 
 fn attention_single_head_cpu(
-    q: &[f32; 2],
+    q: &[f32],
     keys: &[f32],
     values: &[f32],
     seq_len: usize,
     dim: usize,
-) -> [f32; 2] {
-    assert_eq!(dim, 2, "ToyModel supports only dim=2");
+) -> Vec<f32> {
     let scale = 1.0 / (dim as f32).sqrt();
 
     let mut scores = vec![0.0f32; seq_len];
     for t in 0..seq_len {
         let k = &keys[t * dim..t * dim + dim];
-        scores[t] = (q[0] * k[0] + q[1] * k[1]) * scale;
+        let mut dot = 0.0f32;
+        for i in 0..dim {
+            dot += q[i] * k[i];
+        }
+        scores[t] = dot * scale;
     }
     let probs = softmax(&scores);
 
-    let mut out = [0.0f32; 2];
+    let mut out = vec![0.0f32; dim];
     for (t, &p) in probs.iter().enumerate() {
         let v = &values[t * dim..t * dim + dim];
-        out[0] += p * v[0];
-        out[1] += p * v[1];
+        for i in 0..dim {
+            out[i] += p * v[i];
+        }
     }
     out
 }
@@ -524,19 +538,24 @@ fn attention_single_head_cpu(
 // Mirrors CPU semantics while serving as the Metal parity path until real
 // Metal kernels are wired in.
 fn attention_single_head_metal(
-    q: &[f32; 2],
+    q: &[f32],
     keys: &[f32],
     values: &[f32],
     seq_len: usize,
     dim: usize,
-) -> [f32; 2] {
+) -> Vec<f32> {
     attention_single_head_cpu(q, keys, values, seq_len, dim)
 }
 
-fn project_logits(ctx: &[f32; 2], out_proj: &[[f32; 8]; 2]) -> Vec<f32> {
-    let mut logits = vec![0.0f32; 8];
-    for (i, logit) in logits.iter_mut().enumerate().take(8) {
-        *logit = ctx[0] * out_proj[0][i] + ctx[1] * out_proj[1][i];
+fn project_logits(ctx: &[f32], out_proj: &[f32], vocab_size: usize) -> Vec<f32> {
+    let dim = ctx.len();
+    let mut logits = vec![0.0f32; vocab_size];
+    for i in 0..vocab_size {
+        let mut acc = 0.0f32;
+        for j in 0..dim {
+            acc += ctx[j] * out_proj[j * vocab_size + i];
+        }
+        logits[i] = acc;
     }
     logits
 }
@@ -589,7 +608,8 @@ mod tests {
     fn mock_engine_tokenize_roundtrip() {
         let engine = MockEngine::new();
         let tokens = engine.tokenize("hello world").unwrap();
-        assert_eq!(tokens.len(), 2);
+        // "hello", " ", "world"
+        assert_eq!(tokens.len(), 3);
 
         let text = engine.detokenize(&tokens).unwrap();
         assert_eq!(text, "hello world");
@@ -602,7 +622,8 @@ mod tests {
 
         let tokens = engine.tokenize("hello world").unwrap();
         let prefill = engine.prefill(&mut session, &tokens).unwrap();
-        assert_eq!(prefill.tokens_processed, 2);
+        // "hello", " ", "world"
+        assert_eq!(prefill.tokens_processed, 3);
 
         let result = engine.decode(&mut session).unwrap();
         assert!(result.token >= 0);

--- a/crates/llama-tokenizer/src/lib.rs
+++ b/crates/llama-tokenizer/src/lib.rs
@@ -330,6 +330,20 @@ impl WhitespaceTokenizer {
     }
 }
 
+impl VocabState {
+    fn get_or_insert(&mut self, piece: &str) -> i32 {
+        if let Some(&id) = self.reverse_vocab.get(piece) {
+            id
+        } else {
+            let id = self.next_id;
+            self.next_id += 1;
+            self.reverse_vocab.insert(piece.to_string(), id);
+            self.vocab.insert(id, piece.to_string());
+            id
+        }
+    }
+}
+
 impl Default for WhitespaceTokenizer {
     fn default() -> Self {
         Self::new()
@@ -344,17 +358,28 @@ impl Tokenizer for WhitespaceTokenizer {
             .map_err(|_| TokenizerError::EncodingError("tokenizer lock poisoned".to_string()))?;
 
         let mut ids = Vec::new();
-        for word in text.split_whitespace() {
-            let id = if let Some(id) = state.reverse_vocab.get(word) {
-                *id
-            } else {
-                let id = state.next_id;
-                state.next_id += 1;
-                state.reverse_vocab.insert(word.to_string(), id);
-                state.vocab.insert(id, word.to_string());
-                id
-            };
+        if text.is_empty() {
+            return Ok(ids);
+        }
+
+        let mut current_token = String::new();
+        let mut chars = text.chars().peekable();
+
+        while let Some(c) = chars.next() {
+            current_token.push(c);
+            let is_ws = c.is_whitespace();
+
+            while let Some(&next_c) = chars.peek() {
+                if next_c.is_whitespace() == is_ws {
+                    current_token.push(chars.next().unwrap());
+                } else {
+                    break;
+                }
+            }
+
+            let id = state.get_or_insert(&current_token);
             ids.push(id);
+            current_token.clear();
         }
 
         Ok(ids)
@@ -371,8 +396,7 @@ impl Tokenizer for WhitespaceTokenizer {
 
     fn decode_token(&self, token: i32, state: &mut DecodingState) -> TokenizerResult<String> {
         let piece = self.decode_id(token)?;
-        let prepend_space = state.emitted_any && parse_byte_piece(&piece).is_none();
-        let emitted = state.append_bytes(&piece_to_bytes(&piece, prepend_space))?;
+        let emitted = state.append_bytes(piece.as_bytes())?;
         state.emitted_any = true;
         Ok(emitted)
     }
@@ -506,7 +530,8 @@ mod tests {
     fn encode_whitespace_simple() {
         let tok = WhitespaceTokenizer::new();
         let ids = tok.encode("hello world").unwrap();
-        assert_eq!(ids.len(), 2);
+        // word, space, word
+        assert_eq!(ids.len(), 3);
     }
 
     #[test]
@@ -527,7 +552,8 @@ mod tests {
     fn encode_multiple_spaces() {
         let tok = WhitespaceTokenizer::new();
         let ids = tok.encode("hello    world").unwrap();
-        assert_eq!(ids.len(), 2);
+        // word, spaces, word
+        assert_eq!(ids.len(), 3);
     }
 
     #[test]
@@ -555,7 +581,9 @@ mod tests {
         assert_eq!(state.buffer(), "");
         assert_eq!(tok.decode_token(encoded[0], &mut state).unwrap(), "hello");
         assert_eq!(state.buffer(), "hello");
-        assert_eq!(tok.decode_token(encoded[1], &mut state).unwrap(), " world");
+        assert_eq!(tok.decode_token(encoded[1], &mut state).unwrap(), " ");
+        assert_eq!(state.buffer(), "hello ");
+        assert_eq!(tok.decode_token(encoded[2], &mut state).unwrap(), "world");
         assert_eq!(state.buffer(), "hello world");
 
         state.clear();
@@ -587,7 +615,7 @@ mod tests {
         let tok = WhitespaceTokenizer::new();
         let original = "hello 🦀 world 🚀";
         let encoded = tok.encode(original).unwrap();
-        assert_eq!(encoded.len(), 4);
+        assert_eq!(encoded.len(), 7);
         let decoded = tok.decode(&encoded).unwrap();
         assert_eq!(decoded, original);
     }
@@ -598,7 +626,7 @@ mod tests {
         // CJK characters as whitespace-delimited tokens
         let original = "你好 世界";
         let encoded = tok.encode(original).unwrap();
-        assert_eq!(encoded.len(), 2);
+        assert_eq!(encoded.len(), 3);
         let decoded = tok.decode(&encoded).unwrap();
         assert_eq!(decoded, original);
     }
@@ -606,9 +634,9 @@ mod tests {
     #[test]
     fn encode_tabs_and_newlines_treated_as_whitespace() {
         let tok = WhitespaceTokenizer::new();
-        // split_whitespace treats tabs and newlines as delimiters
+        // word, tab, word, newline, word
         let ids = tok.encode("hello\tworld\ntest").unwrap();
-        assert_eq!(ids.len(), 3);
+        assert_eq!(ids.len(), 5);
     }
 
     #[test]
@@ -641,7 +669,8 @@ mod tests {
         let tok = WhitespaceTokenizer::new();
         assert_eq!(tok.vocab_size(), 0);
         tok.encode("hello world hello").unwrap();
-        assert_eq!(tok.vocab_size(), 2);
+        // "hello", " ", "world"
+        assert_eq!(tok.vocab_size(), 3);
     }
 
     #[test]

--- a/crates/llama-tokenizer/tests/bug_repro.rs
+++ b/crates/llama-tokenizer/tests/bug_repro.rs
@@ -1,0 +1,11 @@
+use llama_tokenizer::{Tokenizer, WhitespaceTokenizer};
+
+#[test]
+fn test_whitespace_tokenizer_newline_bug() {
+    let tok = WhitespaceTokenizer::new();
+    let original = "hello\nworld";
+    let encoded = tok.encode(original).unwrap();
+    let decoded = tok.decode(&encoded).unwrap();
+    println!("Original: {:?}, Decoded: {:?}", original, decoded);
+    assert_eq!(decoded, original);
+}

--- a/crates/llama-tokenizer/tests/roundtrip.rs
+++ b/crates/llama-tokenizer/tests/roundtrip.rs
@@ -16,12 +16,10 @@ mod tests {
             ("hello", "hello"),
             ("hello world", "hello world"),
             ("a", "a"),
-            // Pure whitespace tokens are dropped by split_whitespace()
-            // so " " encodes to empty and decodes to ""
-            (" ", ""),
-            ("  ", ""),
-            ("\t", ""),
-            ("\n", ""),
+            (" ", " "),
+            ("  ", "  "),
+            ("\t", "\t"),
+            ("\n", "\n"),
         ];
 
         for (input, expected) in test_cases {
@@ -35,14 +33,13 @@ mod tests {
     fn roundtrip_whitespace_torture() {
         let tok = WhitespaceTokenizer::new();
         let test_cases = vec![
-            // split_whitespace() drops leading/trailing whitespace
-            (" a", "a"),                // leading space stripped
-            ("a ", "a"),                // trailing space stripped
-            ("a  b", "a b"),            // double space collapses to single in join
-            ("  leading", "leading"),   // multiple leading stripped
-            ("trailing  ", "trailing"), // multiple trailing stripped
-            (" \n", ""),                // space + newline = pure whitespace
-            ("\t\t", ""),               // tabs = pure whitespace
+            (" a", " a"),
+            ("a ", "a "),
+            ("a  b", "a  b"),
+            ("  leading", "  leading"),
+            ("trailing  ", "trailing  "),
+            (" \n", " \n"),
+            ("\t\t", "\t\t"),
         ];
 
         for (input, expected) in test_cases {
@@ -72,9 +69,14 @@ mod tests {
         let decoded = tok.decode(&[first_id]).expect("decode failed");
         assert_eq!(decoded, "alpha");
 
-        // Decode just the second token
-        let second_id = multi[1];
-        let decoded2 = tok.decode(&[second_id]).expect("decode failed");
+        // Decode just the second token (the space)
+        let space_id = multi[1];
+        let decoded_space = tok.decode(&[space_id]).expect("decode failed");
+        assert_eq!(decoded_space, " ");
+
+        // Decode the third token
+        let third_id = multi[2];
+        let decoded2 = tok.decode(&[third_id]).expect("decode failed");
         assert_eq!(decoded2, "beta");
     }
 
@@ -170,14 +172,17 @@ mod tests {
         assert_eq!(tok.vocab_size(), 1);
 
         tok.encode("one two").expect("encode failed");
-        assert_eq!(tok.vocab_size(), 2);
+        // "one", " ", "two"
+        assert_eq!(tok.vocab_size(), 3);
 
         tok.encode("one two three").expect("encode failed");
-        assert_eq!(tok.vocab_size(), 3);
+        // "one", " ", "two", " ", "three"
+        // Unique pieces: "one", " ", "two", "three"
+        assert_eq!(tok.vocab_size(), 4);
 
         // Encoding existing word doesn't increase vocab
         tok.encode("one").expect("encode failed");
-        assert_eq!(tok.vocab_size(), 3);
+        assert_eq!(tok.vocab_size(), 4);
     }
 
     // ===== Section D: Error cases =====


### PR DESCRIPTION
This PR addresses several critical bugs and limitations:
1. **KV Layout Bug**: `attention_decode` assumed a `BySequence` layout. It now correctly supports `BySequence`, `ByHead`, and `Transposed` layouts.
2. **Tokenizer Fidelity**: `WhitespaceTokenizer` was lossy. It now preserves all whitespace characters (spaces, tabs, newlines) during encoding and decoding.
3. **ToyModel Generalization**: Refactored `ToyModel` to remove hardcoded dimensions and vocab sizes.

Included regression tests:
- `crates/llama-cli/tests/layout_bug.rs`
- `crates/llama-tokenizer/tests/bug_repro.rs`

---
*PR created automatically by Jules for task [15311759231177581680](https://jules.google.com/task/15311759231177581680) started by @stevei101*