### PR TITLE
fix: address PR #93 review findings (blockers + majors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to llama.rs are documented here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project is
+pre-1.0 and does not yet emit semver-stable releases.
+
+Each entry is tagged with the PR that introduced it.
+
+## [Unreleased]
+
+### Changed (breaking output)
+
+- **`llama-tokenizer`: `WhitespaceTokenizer` now preserves whitespace as its
+  own tokens** *(via #92)*. Previously, `split_whitespace()` dropped leading,
+  trailing, and interior whitespace runs, so `"hello world"` encoded to 2
+  token ids and `"  a  "` round-tripped to `"a"`. The new encoder treats each
+  run of whitespace and each run of non-whitespace as a separate piece, so
+  `"hello world"` encodes to 3 ids and round-trip is bit-perfect.
+
+  Any caller that hard-codes token counts or persists stored token-id
+  sequences from pre-change versions will break. There is no compatibility
+  shim — re-encode prompts and rebuild any artifacts that store token-id
+  sequences.
+
+### Changed
+
+- **`llama-kv` / `llama-models`: `KVLayout` consolidated** *(via #97)*. The
+  enum lives in `llama-kv` only; `llama-models` re-exports it as
+  `llama_models::KVLayout`. The duplicated definition is gone, and the CLI
+  no longer needs a translation match between the two.
+
+- **`llama-models::attention_decode`: capacity contract clarified** *(via
+  #92, documented in #97)*. `keys` and `values` must now be pre-allocated to
+  full capacity (`max_seq_len * n_heads * head_dim`), not trimmed to the
+  populated `seq_len * n_heads * head_dim`. This is required because the
+  `ByHead` and `Transposed` layouts stride on `max_seq_len`. Callers passing
+  a slice trimmed to `seq_len` will fail the shape check (regression test:
+  `attention_decode_rejects_undersized_buffer`).
+
+- **`llama-agents::orchestration`: multi-dependency input plumbing** *(landed
+  on develop ahead of #97)*. `RoleExecutor` is now `fn(&[&Artifact]) ->
+  Artifact`, receiving every dependency's output as a slice in
+  `OrchestrationTask.depends_on` order. The previous signature silently
+  collapsed multi-dep inputs to `depends_on[0]`. `inputs[0]` remains the
+  primary handoff contract-validated against the node's `HandoffContract`;
+  secondary deps are scheduling/data inputs and are not contract-validated.
+
+### Fixed
+
+- **KV layout bug** *(via #92)*: `attention_decode` is now layout-aware and
+  reads K/V via the layout's indexing function instead of a fixed
+  `BySequence`-only stride. Regression test:
+  `crates/llama-cli/tests/layout_bug.rs`.
+- **Tokenizer fidelity** *(via #92)*: round-trip is now bit-perfect for
+  whitespace, tabs, newlines, multi-byte UTF-8, and emoji. See
+  `crates/llama-tokenizer/tests/`.
+- **`ToyModel`** *(via #92)*: generalized to arbitrary `dim` / `vocab_size`
+  instead of hardcoded `dim=2`, `vocab=8`.
+- **Workspace `Cargo.toml`** *(via #92)*: removed duplicate `crates/llama-rag`
+  member entry.

--- a/crates/llama-agents/src/orchestration.rs
+++ b/crates/llama-agents/src/orchestration.rs
@@ -104,6 +104,12 @@ pub fn validate_handoff(
 pub struct OrchestrationTask {
     pub id: String,
     pub role: AgentRole,
+    /// Upstream task ids that must complete before this one runs.
+    ///
+    /// **Order matters.** The executor receives dependency artifacts as a
+    /// slice in this declaration order, and contract validation runs against
+    /// `inputs[0]` — the *primary* handoff. Secondary deps are scheduling /
+    /// data inputs available to the executor but are not contract-validated.
     pub depends_on: Vec<String>,
 }
 

--- a/crates/llama-cli/src/lib.rs
+++ b/crates/llama-cli/src/lib.rs
@@ -185,11 +185,6 @@ impl TinyModel {
         let seq_len = kv_cache.seq_len;
 
         // 6. Attention: Q against all cached K, V
-        let layout = match kv_cache.layout {
-            llama_kv::KVLayout::BySequence => llama_models::KVLayout::BySequence,
-            llama_kv::KVLayout::ByHead => llama_models::KVLayout::ByHead,
-            llama_kv::KVLayout::Transposed => llama_models::KVLayout::Transposed,
-        };
         let attn_out = attention_decode(
             &q,
             &kv_cache.k,
@@ -198,7 +193,7 @@ impl TinyModel {
             kv_cache.max_seq_len,
             c.n_heads,
             c.head_dim,
-            layout,
+            kv_cache.layout,
         )?;
 
         // 7. Output projection + residual
@@ -253,11 +248,6 @@ impl TinyModel {
             // output. Multi-layer models would need full computation per token.
             if pos == token_ids.len() - 1 {
                 let seq_len = kv_cache.seq_len;
-                let layout = match kv_cache.layout {
-                    llama_kv::KVLayout::BySequence => llama_models::KVLayout::BySequence,
-                    llama_kv::KVLayout::ByHead => llama_models::KVLayout::ByHead,
-                    llama_kv::KVLayout::Transposed => llama_models::KVLayout::Transposed,
-                };
 
                 let attn_out = attention_decode(
                     &q,
@@ -267,7 +257,7 @@ impl TinyModel {
                     kv_cache.max_seq_len,
                     c.n_heads,
                     c.head_dim,
-                    layout,
+                    kv_cache.layout,
                 )?;
                 let attn_proj = Self::matvec(&attn_out, &self.w_o, d, d);
                 let x_after_attn: Vec<f32> =

--- a/crates/llama-models/Cargo.toml
+++ b/crates/llama-models/Cargo.toml
@@ -10,3 +10,4 @@ repository.workspace = true
 bytemuck = "1"
 safetensors = "0.5"
 thiserror.workspace = true
+llama-kv = { path = "../llama-kv" }

--- a/crates/llama-models/src/lib.rs
+++ b/crates/llama-models/src/lib.rs
@@ -86,18 +86,7 @@ impl ModelWeights {
     }
 }
 
-/// Layout policy for KV cache memory.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KVLayout {
-    /// Contiguous by sequence position: `[seq_len][heads][head_dim]`
-    BySequence,
-
-    /// Contiguous by head: `[heads][seq_len][head_dim]`
-    ByHead,
-
-    /// Transposed for attention: `[heads][head_dim][seq_len]`
-    Transposed,
-}
+pub use llama_kv::KVLayout;
 
 /// Root mean square normalization.
 pub fn rms_norm(input: &[f32], weight: &[f32], eps: f32) -> Result<Vec<f32>, ModelError> {
@@ -167,9 +156,18 @@ pub fn apply_rope(
     Ok(())
 }
 
-/// Single-step decode attention:
+/// Single-step decode attention against a populated KV cache.
+///
 /// - `query`: `[n_heads * head_dim]`
-/// - `keys`/`values`: backing storage for KV cache
+/// - `keys` / `values`: backing storage for the KV cache. The buffer must be
+///   pre-allocated to **full capacity** (`max_seq_len * n_heads * head_dim`),
+///   not trimmed to `seq_len * n_heads * head_dim`. The `ByHead` and
+///   `Transposed` layouts stride on `max_seq_len`, so a tighter slice would
+///   index past the end. Only positions `0..seq_len` are read.
+/// - `seq_len`: number of populated positions to attend over.
+/// - `max_seq_len`: cache capacity in positions (the value used at allocation).
+/// - `layout`: must match the layout the cache was written with; otherwise
+///   reads pick up wrong K/V values.
 /// - output: `[n_heads * head_dim]`
 #[allow(clippy::too_many_arguments)]
 pub fn attention_decode(
@@ -449,6 +447,34 @@ mod tests {
 
         // Each head should match its key/value
         assert_close(&out, &query, 1e-5);
+    }
+
+    #[test]
+    fn attention_decode_rejects_undersized_buffer() {
+        // Capacity contract: keys/values must be sized for max_seq_len, not
+        // just seq_len. A buffer trimmed to seq_len * n_heads * head_dim
+        // would index past the end under ByHead / Transposed strides.
+        let n_heads = 2;
+        let head_dim = 2;
+        let seq_len = 1;
+        let max_seq_len = 4;
+
+        let query = vec![0.0f32; n_heads * head_dim];
+        // Sized to seq_len, not max_seq_len — should be rejected.
+        let undersized = vec![0.0f32; seq_len * n_heads * head_dim];
+
+        let err = attention_decode(
+            &query,
+            &undersized,
+            &undersized,
+            seq_len,
+            max_seq_len,
+            n_heads,
+            head_dim,
+            KVLayout::ByHead,
+        )
+        .expect_err("undersized buffer must be rejected");
+        assert!(matches!(err, ModelError::Shape(_)));
     }
 
     #[test]

--- a/crates/llama-tokenizer/src/lib.rs
+++ b/crates/llama-tokenizer/src/lib.rs
@@ -395,6 +395,10 @@ impl Tokenizer for WhitespaceTokenizer {
     }
 
     fn decode_token(&self, token: i32, state: &mut DecodingState) -> TokenizerResult<String> {
+        // WhitespaceTokenizer stores each piece (including whitespace runs)
+        // as its own vocab entry — no <0xNN> byte pieces, no implicit
+        // leading-space insertion, so emit raw bytes directly. BPE-style
+        // tokenizers still need parse_byte_piece / piece_to_bytes.
         let piece = self.decode_id(token)?;
         let emitted = state.append_bytes(piece.as_bytes())?;
         state.emitted_any = true;


### PR DESCRIPTION
Follow-up to #93. **Rebased** onto develop after [debadf9](https://github.com/stevedores-org/llama.rs/commit/debadf9) landed the multi-dep input plumbing fix with a slice-based `RoleExecutor = fn(&[&Artifact]) -> Artifact` API. This PR now contains only the non-overlapping changes.

## What changed (current commit)

- **`KVLayout` consolidation.** Canonical definition stays in `llama-kv`; `llama-models` re-exports it (`pub use llama_kv::KVLayout;`). `llama-cli` no longer needs the translation `match` blocks in `forward_prefill` / `forward_decode` — `kv_cache.layout` is passed directly. New edge: `llama-models -> llama-kv` (acyclic).
- **`attention_decode` capacity-contract documentation + regression test.** New doc comment makes the requirement explicit: `keys`/`values` must be sized to full `max_seq_len * n_heads * head_dim` (required by `ByHead` and `Transposed` striding). New test `attention_decode_rejects_undersized_buffer` confirms the existing shape check rejects an undersized slice.
- **Tokenizer bypass comment.** `parse_byte_piece` / `piece_to_bytes` are still used by the BPE path, so they're not dead. Added a comment on `WhitespaceTokenizer::decode_token` explaining why this impl can skip them.
- **`OrchestrationTask.depends_on` doc.** Documents the `inputs[0]` = primary input convention introduced by debadf9, so the slice-order semantics aren't load-bearing implicit knowledge.
- **`CHANGELOG.md`.** New file at repo root with an Unreleased section, each entry tagged by the PR that introduced it. Flags the tokenizer behavior change from #92 as breaking output (token counts shift, e.g. `"hello world"` now encodes to 3 ids instead of 2).

## What was dropped during rebase

The original PR included a competing fix for the multi-dep input plumbing using a `WorkflowInput { primary, deps }` struct and a `HandoffContract.to` removal. Both are superseded by debadf9, which uses a `&[&Artifact]` slice API and retains `to` (changing the Fixer's contract `from: Fixer -> from: Reviewer` instead). The current PR respects that API choice.

## Verification

- `cargo fmt --all`
- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — all green

## Merge order

Targeting `develop`. Once this merges, #93 (`develop` → `main`) will pull these fixes through as part of the same flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)